### PR TITLE
perf(loader): replace all querySelectorAll methods with getElementsByTagName

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -63,7 +63,7 @@ export class Loader {
       HTMLTemplateElement.bootstrap(doc);
     }
 
-    var template = doc.querySelector('template');
+    var template = doc.getElementsByTagName('template')[0];
 
     if(!template){
       throw new Error(`There was no template element found in '${url}'.`);

--- a/src/template-registry-entry.js
+++ b/src/template-registry-entry.js
@@ -29,7 +29,7 @@ export class TemplateRegistryEntry {
         useResources, i, ii, current, src;
 
     this.template = template;
-    useResources = template.content.querySelectorAll('require');
+    useResources = template.content.getElementsByTagName('require');
     this.dependencies = new Array(useResources.length);
 
     if(useResources.length === 0){


### PR DESCRIPTION
The loader was looking up elements in the DOM, more specifically <template> and <require> using document.querySelectorAll. While this method works, the querySelectorAll method returns a StaticNodeList which means the matched elements are matched upfront. This is in comparison to getElementsByTagName which returns a DynamicNodeList which is a living representation of the DOM and thus faster as no pre-computation is performed, results in faster performance.