### PR TITLE
fix(loader): Use correct import for core-js

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {TemplateRegistryEntry} from './template-registry-entry';
 
 var hasTemplateElement = ('content' in document.createElement('template'));


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177