### PR TITLE
Adds dependency on `core-js`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "devDependencies": {
       "babel": "npm:babel-core@^5.8.24",
       "babel-runtime": "npm:babel-runtime@^5.8.24",
-      "core-js": "npm:core-js@^1.2.6"
+      "core-js": "^1.2.6"
     }
   },
   "dependencies": {
     "aurelia-metadata": "^1.0.0-beta.1",
-    "aurelia-path": "^1.0.0-beta.1"
+    "aurelia-path": "^1.0.0-beta.1",
+    "core-js": "npm:core-js@^1.2.6"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.12",


### PR DESCRIPTION
If you don't directly depend on `core-js` (which the skeleton app does) then `aurelia-loader` will fail to load because it can't find `core-js`.  I was able to work around this by manually telling SystemJS that `aurelia-loader` depends on `core-js`, but as a user I shouldn't have to do that.